### PR TITLE
replace test with debug, wrong name

### DIFF
--- a/template/android/keystore/signingConfigs.gradle
+++ b/template/android/keystore/signingConfigs.gradle
@@ -12,7 +12,7 @@ android {
             storePassword keystoreConfig.storePassword
         }
 
-        test {
+        debug {
             storeFile file("../keystore/test.keystore")
             storePassword "qatest"
             keyAlias "test"


### PR DESCRIPTION
Gradle ищет keystore с названием debug, а в keystore он назывался test. Из-за этого каждая версия имела разную подпись -> не работал накат