### PR TITLE
no-task - исправление лишнего вызова onRefresh

### DIFF
--- a/packages/swipe_refresh/CHANGELOG.md
+++ b/packages/swipe_refresh/CHANGELOG.md
@@ -1,4 +1,8 @@
-##0.0.1-dev.9
+## 0.0.1-dev.12
+
+* Fix unnecessary onRefresh call on CupertinoSwipeRefresh
+
+## 0.0.1-dev.9
 
 * Added keyboardDismissBehavior (Material) and scroll physics
 

--- a/packages/swipe_refresh/lib/src/cupertino_swipe_refresh.dart
+++ b/packages/swipe_refresh/lib/src/cupertino_swipe_refresh.dart
@@ -103,7 +103,7 @@ class _CupertinoSwipeRefreshState extends SwipeRefreshBaseState<CupertinoSwipeRe
   @override
   void onUpdateState(SwipeRefreshState state) {
     if (state == SwipeRefreshState.loading) {
-      _scrollController.jumpTo(-(widget.refreshTriggerPullDistance + 5));
+      _scrollController.jumpTo(-(widget.refreshIndicatorExtent + 5));
     }
 
     if (state == SwipeRefreshState.hidden) {


### PR DESCRIPTION
баг был найден при [исправлении бага на ios](https://github.com/surfstudio/labelcom-flutter/pull/818)