### PR TITLE
неправильный заголовок функции

### DIFF
--- a/packages/geolocation/CHANGELOG.md
+++ b/packages/geolocation/CHANGELOG.md
@@ -1,3 +1,8 @@
 ## 0.0.1-dev.0
 
 * Initial release
+
+## 0.1.0-dev.6
+
+* fix bug witch with handler signature for Future.catchError
+

--- a/packages/geolocation/CHANGELOG.md
+++ b/packages/geolocation/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 * Initial release
 
-## 0.1.0-dev.6
+## 0.0.1-dev.6
 
 * fix bug witch with handler signature for Future.catchError
 

--- a/packages/geolocation/lib/src/impl/permission/default_location_permission_service.dart
+++ b/packages/geolocation/lib/src/impl/permission/default_location_permission_service.dart
@@ -66,7 +66,7 @@ class DefaultLocationPermissionService implements LocationPermissionService {
     }
   }
 
-  Future<PermissionStatus> _handleError(Exception error, String stacktrace) {
+  Future<PermissionStatus> _handleError(Object error, Object stacktrace) {
     if (error is PlatformException) {
       throw error;
     }


### PR DESCRIPTION
при использовании библиотеки возникала ошибка:
`Invalid argument (onError): Error handler must accept one Object or one Object and a StackTrace as arguments, and return a a val`
Из за неправильного заголовка функции, передаваемой в `Future.catchError`
