### PR TITLE
FLT-1259 Исправить проблему в otp_autofill

### DIFF
--- a/packages/otp_autofill/android/src/main/kotlin/ru/surfstudio/otp_autofill/OTPPlugin.kt
+++ b/packages/otp_autofill/android/src/main/kotlin/ru/surfstudio/otp_autofill/OTPPlugin.kt
@@ -171,7 +171,7 @@ public class OTPPlugin : FlutterPlugin, MethodCallHandler, PluginRegistry.Activi
         }
 
         val intentFilter = IntentFilter(SmsRetriever.SMS_RETRIEVED_ACTION)
-        this.activity?.registerReceiver(smsUserConsentBroadcastReceiver, intentFilter)
+        this.activity?.registerReceiver(smsUserConsentBroadcastReceiver, intentFilter, SmsRetriever.SEND_PERMISSION, null)
     }
 
     private fun registerSmsRetrieverBroadcastReceiver() {


### PR DESCRIPTION
### [FLT-1259](https://jira.surfstudio.ru/browse/FLT-1259)
Based on [article](https://developers.google.com/identity/sms-retriever/user-consent/request#2_start_listening_for_incoming_messages).
But code in this article has wrong `registerReceiver`'s arguments order.