### PR TITLE
Introduce new CI/CD tools

### DIFF
--- a/tools/ci-cd/analysis_options.yaml
+++ b/tools/ci-cd/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: package:surf_lint_rules/analysis_options.yaml

--- a/tools/ci-cd/bin/ci.dart
+++ b/tools/ci-cd/bin/ci.dart
@@ -1,0 +1,72 @@
+// Copyright (c) 2019-present,  SurfStudio LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'dart:io';
+
+import 'package:args/command_runner.dart';
+import 'package:ci_cd/ci.dart';
+
+void main(List<String> args) {
+  CommandRunner<void>('tools/ci', 'tools for automate some ci/cd cases')
+    ..addCommand(CheckDevBranch())
+    ..run(args);
+}
+
+class CheckDevBranch extends Command<void> {
+  @override
+  String get name => 'check-dev-branch';
+
+  @override
+  String get description =>
+      'Validate developer branch for compliance with our conventions.';
+
+  @override
+  void run() {
+    final changelogContent = readChangelog();
+    final importance = getDevChangesImportance(changelogContent);
+    if (importance == ChangesImportance.unknown) {
+      printErrorMessage("Can't get changes importance.");
+    }
+
+    if (getDevChangesCount(changelogContent) == 0) {
+      printErrorMessage("Can't get introduces changes.");
+    }
+  }
+}
+
+void printErrorMessage(String verbose, {bool withDevChangelogExample = true}) {
+  [
+    '\u2757 Invalid changelog format. $verbose',
+  ].forEach(stderr.writeln);
+
+  if (withDevChangelogExample) {
+    [
+      'Changelog should look like:',
+      '----------------------------',
+      '# Changelog',
+      '',
+      '## MAJOR | MINOR | PATCH',
+      '',
+      '* change 1',
+      '* change 2',
+      '* ...',
+      '',
+      '## ....',
+      '',
+      '----------------------------',
+    ].forEach(stdout.writeln);
+  }
+
+  exit(1);
+}

--- a/tools/ci-cd/bin/ci.dart
+++ b/tools/ci-cd/bin/ci.dart
@@ -22,6 +22,7 @@ void main(List<String> args) {
     ..addCommand(CheckDevBranch())
     ..addCommand(BumpDevVersion())
     ..addCommand(PushNewVersion())
+    ..addCommand(PublishToPub())
     ..run(args);
 }
 
@@ -92,6 +93,19 @@ class PushNewVersion extends Command<void> {
     final version = getPackageVersion(readPubspec());
 
     pushNewVersion(version);
+  }
+}
+
+class PublishToPub extends Command<void> {
+  @override
+  String get name => 'publish';
+
+  @override
+  String get description => 'Publish to pub.dev.';
+
+  @override
+  void run() {
+    publishToPub();
   }
 }
 

--- a/tools/ci-cd/bin/ci.dart
+++ b/tools/ci-cd/bin/ci.dart
@@ -21,6 +21,7 @@ void main(List<String> args) {
   CommandRunner<void>('tools/ci', 'tools for automate some ci/cd cases')
     ..addCommand(CheckDevBranch())
     ..addCommand(BumpDevVersion())
+    ..addCommand(PushNewVersion())
     ..run(args);
 }
 
@@ -76,6 +77,21 @@ class BumpDevVersion extends Command<void> {
         DateTime.now(),
       ),
     );
+  }
+}
+
+class PushNewVersion extends Command<void> {
+  @override
+  String get name => 'push-new-version';
+
+  @override
+  String get description => 'Push new version.';
+
+  @override
+  void run() {
+    final version = getPackageVersion(readPubspec());
+
+    pushNewVersion(version);
   }
 }
 

--- a/tools/ci-cd/lib/ci.dart
+++ b/tools/ci-cd/lib/ci.dart
@@ -15,5 +15,6 @@
 export 'package:ci_cd/src/changelog.dart';
 export 'package:ci_cd/src/git.dart';
 export 'package:ci_cd/src/importance.dart';
+export 'package:ci_cd/src/pub.dart';
 export 'package:ci_cd/src/pubspec.dart';
 export 'package:ci_cd/src/version.dart';

--- a/tools/ci-cd/lib/ci.dart
+++ b/tools/ci-cd/lib/ci.dart
@@ -1,0 +1,16 @@
+// Copyright (c) 2019-present,  SurfStudio LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+export 'package:ci_cd/src/changelog.dart';
+export 'package:ci_cd/src/importance.dart';

--- a/tools/ci-cd/lib/ci.dart
+++ b/tools/ci-cd/lib/ci.dart
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 export 'package:ci_cd/src/changelog.dart';
+export 'package:ci_cd/src/git.dart';
 export 'package:ci_cd/src/importance.dart';
 export 'package:ci_cd/src/pubspec.dart';
 export 'package:ci_cd/src/version.dart';

--- a/tools/ci-cd/lib/ci.dart
+++ b/tools/ci-cd/lib/ci.dart
@@ -14,3 +14,5 @@
 
 export 'package:ci_cd/src/changelog.dart';
 export 'package:ci_cd/src/importance.dart';
+export 'package:ci_cd/src/pubspec.dart';
+export 'package:ci_cd/src/version.dart';

--- a/tools/ci-cd/lib/src/changelog.dart
+++ b/tools/ci-cd/lib/src/changelog.dart
@@ -1,0 +1,129 @@
+// Copyright (c) 2019-present,  SurfStudio LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:ci_cd/src/importance.dart';
+
+const _changeMark = '* ';
+const _versionMark = '## ';
+
+Iterable<String> readChangelog() {
+  final changelog = File('CHANGELOG.md');
+  if (!changelog.existsSync()) {
+    return [];
+  }
+
+  return LineSplitter.split(changelog.readAsStringSync());
+}
+
+ChangesImportance getChangesImportanceForStable(Iterable<String> changelog) =>
+    changelog.fold(ChangesImportance.unknown, (previousValue, line) {
+      final trimmedLine = line.trim();
+      if (!trimmedLine.startsWith(_changeMark)) {
+        return previousValue;
+      }
+
+      final lineImportance = getLineImportance(trimmedLine);
+
+      return lineImportance > previousValue ? lineImportance : previousValue;
+    });
+
+int getDevChangesCount(Iterable<String> changelog) {
+  if (getDevChangesImportance(changelog) == ChangesImportance.unknown) {
+    return 0;
+  }
+
+  final indices = getReleaseLineIndices(changelog).toList();
+
+  return indices.isNotEmpty
+      ? changelog
+          .toList()
+          .sublist(indices[0] + 1, indices[1])
+          .where((line) => line.trim().startsWith(_changeMark))
+          .length
+      : 0;
+}
+
+ChangesImportance getDevChangesImportance(Iterable<String> changelog) {
+  const _importanceMap = {
+    '## major': ChangesImportance.major,
+    '## minor': ChangesImportance.minor,
+    '## patch': ChangesImportance.patch,
+  };
+
+  if (changelog.length < 3) {
+    return ChangesImportance.unknown;
+  }
+
+  final potentialSeverityLine = (changelog.iterator
+        ..moveNext()
+        ..moveNext()
+        ..moveNext())
+      .current
+      .trim()
+      .toLowerCase();
+
+  return _importanceMap[potentialSeverityLine] ?? ChangesImportance.unknown;
+}
+
+ChangesImportance getLineImportance(String line) =>
+    ChangesImportance.values.firstWhere(
+      (values) => line.toLowerCase().endsWith('($values)'),
+      orElse: () => ChangesImportance.unknown,
+    );
+
+Iterable<int> getReleaseLineIndices(Iterable<String> content) {
+  var lineIndex = 0;
+
+  return content.expand((line) {
+    lineIndex++;
+
+    return line.startsWith(_versionMark) ? [lineIndex - 1] : [];
+  });
+}
+
+Iterable<String> patchChangelog(
+  Iterable<String> originalContent,
+  String newVersion,
+  ChangesImportance importance,
+  DateTime changesDate,
+) {
+  final content = originalContent.toList();
+  final releaseLineIndexes = getReleaseLineIndices(content).toList();
+
+  final patchedContent = [
+    ...content.sublist(0, 2),
+    '$_versionMark$newVersion - ${changesDate.year}-${changesDate.month.toString().padLeft(2, '0')}-${changesDate.day.toString().padLeft(2, '0')}',
+    ...content
+        .sublist(releaseLineIndexes[0] + 1, releaseLineIndexes[1])
+        .map((line) {
+      final trimmedLine = line.trim();
+
+      if (trimmedLine.startsWith(_changeMark)) {
+        return '$trimmedLine ($importance)';
+      }
+
+      return trimmedLine;
+    }),
+    ...content.sublist(releaseLineIndexes[1]),
+  ];
+
+  return patchedContent;
+}
+
+void saveChangelog(Iterable<String> content) {
+  File('CHANGELOG.md').writeAsStringSync('${content.join('\n')}\n');
+}

--- a/tools/ci-cd/lib/src/changelog.dart
+++ b/tools/ci-cd/lib/src/changelog.dart
@@ -16,6 +16,7 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:ci_cd/src/importance.dart';
+import 'package:pub_semver/pub_semver.dart';
 
 const _changeMark = '* ';
 const _versionMark = '## ';
@@ -97,7 +98,7 @@ Iterable<int> getReleaseLineIndices(Iterable<String> content) {
 
 Iterable<String> patchChangelog(
   Iterable<String> originalContent,
-  String newVersion,
+  Version newVersion,
   ChangesImportance importance,
   DateTime changesDate,
 ) {

--- a/tools/ci-cd/lib/src/git.dart
+++ b/tools/ci-cd/lib/src/git.dart
@@ -1,0 +1,24 @@
+import 'dart:io';
+
+import 'package:pub_semver/pub_semver.dart';
+
+void pushNewVersion(Version version) {
+  final gitCommands = [
+    ['config', 'user.name', 'github-actions'],
+    ['config', 'user.email', 'github-actions@github.com'],
+    ['add', '.'],
+    ['commit', '-m', '🔖 Update version to $version'],
+    ['tag', '-a', version.toString(), '-m', '🔖 Release version $version'],
+    ['push'],
+    ['push', 'origin', version.toString()],
+  ];
+
+  for (final command in gitCommands) {
+    final result = Process.runSync('git', command);
+    stdout.write(result.stdout);
+    stderr.write(result.stderr);
+    if (result.exitCode != 0) {
+      exit(exitCode);
+    }
+  }
+}

--- a/tools/ci-cd/lib/src/importance.dart
+++ b/tools/ci-cd/lib/src/importance.dart
@@ -1,0 +1,48 @@
+// Copyright (c) 2019-present,  SurfStudio LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+class ChangesImportance implements Comparable<ChangesImportance> {
+  const ChangesImportance._(this._value);
+
+  static const unknown = ChangesImportance._('unknown');
+  static const patch = ChangesImportance._('patch');
+  static const minor = ChangesImportance._('minor');
+  static const major = ChangesImportance._('major');
+
+  static const values = [
+    ChangesImportance.unknown,
+    ChangesImportance.patch,
+    ChangesImportance.minor,
+    ChangesImportance.major,
+  ];
+
+  final String _value;
+
+  static ChangesImportance fromString(String value) => values.firstWhere(
+        (val) => val._value == value.toLowerCase(),
+        orElse: () => ChangesImportance.unknown,
+      );
+
+  @override
+  String toString() => _value;
+
+  @override
+  int compareTo(ChangesImportance other) =>
+      values.indexOf(this).compareTo(values.indexOf(other));
+
+  bool operator <(ChangesImportance other) => compareTo(other) < 0;
+  bool operator <=(ChangesImportance other) => compareTo(other) <= 0;
+  bool operator >(ChangesImportance other) => compareTo(other) > 0;
+  bool operator >=(ChangesImportance other) => compareTo(other) >= 0;
+}

--- a/tools/ci-cd/lib/src/pub.dart
+++ b/tools/ci-cd/lib/src/pub.dart
@@ -1,0 +1,48 @@
+import 'dart:io';
+
+const _pubCredentialsKey = 'PUB_CREDENTIALS';
+
+void publishToPub() {
+  final pubCachePath = getPubCachePath();
+  Directory(pubCachePath).createSync(recursive: true);
+
+  final credential = Platform.environment[_pubCredentialsKey];
+  if (credential == null) {
+    throw ArgumentError.value(
+      credential,
+      _pubCredentialsKey,
+      'Make sure you setup environment variable',
+    );
+  }
+
+  File('$pubCachePath/credentials.json').writeAsStringSync(
+    credential,
+    mode: FileMode.writeOnly,
+    flush: true,
+  );
+
+  final pubCommands = [
+    ['pub', 'publish', '--force'],
+  ];
+
+  for (final command in pubCommands) {
+    final result = Process.runSync('dart', command);
+    stdout.write(result.stdout);
+    stderr.write(result.stderr);
+    if (result.exitCode != 0) {
+      exit(exitCode);
+    }
+  }
+}
+
+const _pubCacheKey = 'PUB_CACHE';
+
+String getPubCachePath() {
+  if (Platform.environment.containsKey(_pubCacheKey)) {
+    return Platform.environment[_pubCacheKey]!;
+  } else if (Platform.operatingSystem == 'windows') {
+    return '${Platform.environment['APPDATA']}/Pub/Cache';
+  } else {
+    return '${Platform.environment['HOME']}/.pub-cache';
+  }
+}

--- a/tools/ci-cd/lib/src/pubspec.dart
+++ b/tools/ci-cd/lib/src/pubspec.dart
@@ -1,0 +1,47 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:pub_semver/pub_semver.dart';
+
+Iterable<String> readPubspec() {
+  final pubspec = File('pubspec.yaml');
+  if (!pubspec.existsSync()) {
+    return [];
+  }
+
+  return LineSplitter.split(pubspec.readAsStringSync());
+}
+
+void savePubspec(Iterable<String> content) {
+  File('pubspec.yaml').writeAsStringSync('${content.join('\n')}\n');
+}
+
+Version getPackageVersion(Iterable<String> pubspec) {
+  const versionPattern = 'version:';
+
+  final versionString = pubspec
+      .firstWhere(
+        (line) => line.trim().startsWith(versionPattern),
+        orElse: () => '$versionPattern 0.0.0',
+      )
+      .substring(versionPattern.length + 1);
+
+  return Version.parse(versionString);
+}
+
+Iterable<String> patchPubspec(
+  Iterable<String> originalContent,
+  Version newVersion,
+) {
+  const versionPattern = 'version:';
+
+  final patchedContent = originalContent.map((line) {
+    if (line.startsWith(versionPattern)) {
+      return '$versionPattern $newVersion';
+    }
+
+    return line;
+  });
+
+  return patchedContent;
+}

--- a/tools/ci-cd/lib/src/version.dart
+++ b/tools/ci-cd/lib/src/version.dart
@@ -1,0 +1,25 @@
+import 'package:pub_semver/pub_semver.dart';
+
+const _devPattern = 'dev';
+
+Version bumpPackageVersion(Version version) {
+  if (!version.isPreRelease) {
+    return Version(
+      version.major,
+      version.minor,
+      version.patch,
+      pre: '$_devPattern.1',
+    );
+  }
+
+  final currentDevVersion = version.preRelease
+      // ignore: implicit_dynamic_parameter
+      .firstWhere((item) => item is int, orElse: () => 0) as int;
+
+  return Version(
+    version.major,
+    version.minor,
+    version.patch,
+    pre: '$_devPattern.${currentDevVersion + 1}',
+  );
+}

--- a/tools/ci-cd/pubspec.yaml
+++ b/tools/ci-cd/pubspec.yaml
@@ -1,0 +1,9 @@
+name: ci_cd
+description: A command-line tool for helps integrate and deploy Surf Gear.
+publish_to: none
+
+environment:
+  sdk: ">=2.12.0 <3.0.0"
+
+dev_dependencies:
+  surf_lint_rules: ^1.0.0

--- a/tools/ci-cd/pubspec.yaml
+++ b/tools/ci-cd/pubspec.yaml
@@ -5,5 +5,9 @@ publish_to: none
 environment:
   sdk: ">=2.12.0 <3.0.0"
 
+dependencies:
+  args: ^2.1.0
+
 dev_dependencies:
   surf_lint_rules: ^1.0.0
+  test: ^1.15.7

--- a/tools/ci-cd/pubspec.yaml
+++ b/tools/ci-cd/pubspec.yaml
@@ -7,6 +7,7 @@ environment:
 
 dependencies:
   args: ^2.1.0
+  pub_semver: ^2.0.0
 
 dev_dependencies:
   surf_lint_rules: ^1.0.0

--- a/tools/ci-cd/test/changelog_test.dart
+++ b/tools/ci-cd/test/changelog_test.dart
@@ -1,0 +1,242 @@
+// Copyright (c) 2019-present,  SurfStudio LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+@TestOn('vm')
+import 'package:ci_cd/src/changelog.dart';
+import 'package:ci_cd/src/importance.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('getChangesImportanceForStable', () {
+    expect(
+      getChangesImportanceForStable([
+        '# Changelog',
+        '',
+        '## 0.0.4-dev.3 - 2021-03-24',
+        '',
+        '* Fixed loading and error builders on empty stream data (PATCH)',
+        '* Update README.md (PATCH)',
+        '',
+        '## 0.0.4-dev.1 - 2021-03-24',
+        '',
+        '* Up rxdart dependency (MINOR)',
+        '',
+        '## 0.0.2 - 2021-03-08',
+        '',
+        '* Initial release',
+        '',
+      ]),
+      equals(ChangesImportance.minor),
+    );
+  });
+
+  group('getDevChangesImportance returns', () {
+    test('unknown for empty changelog', () {
+      expect(getDevChangesImportance([]), equals(ChangesImportance.unknown));
+      expect(
+        getDevChangesImportance(['# Changelog', '']),
+        equals(ChangesImportance.unknown),
+      );
+    });
+
+    test('unknown for changelog without dev block', () {
+      expect(
+        getDevChangesImportance([
+          '# Changelog',
+          '',
+          '## 0.0.4-dev.3 - 2021-03-24',
+          '',
+          '* Fixed loading and error builders on empty stream data',
+          '* Update README.md',
+        ]),
+        equals(ChangesImportance.unknown),
+      );
+    });
+
+    test('unknown for unknown importance form changelog with dev block', () {
+      expect(
+        getDevChangesImportance([
+          '# Changelog',
+          '',
+          '## NEW FEATURE',
+          '',
+          '* changes',
+          '* changes',
+        ]),
+        equals(ChangesImportance.unknown),
+      );
+    });
+
+    test('importance for changelog in dev block', () {
+      expect(
+        getDevChangesImportance([
+          '# Changelog',
+          '',
+          '## MAJOR',
+          '',
+          '* changes',
+          '* changes',
+        ]),
+        equals(ChangesImportance.major),
+      );
+      expect(
+        getDevChangesImportance([
+          '# Changelog',
+          '',
+          '## MINOR',
+          '',
+          '* changes',
+          '* changes',
+        ]),
+        equals(ChangesImportance.minor),
+      );
+      expect(
+        getDevChangesImportance([
+          '# Changelog',
+          '',
+          '## PATCH',
+          '',
+          '* changes',
+        ]),
+        equals(ChangesImportance.patch),
+      );
+    });
+  });
+
+  test(
+    'getDevChangesCount returns count of developer changes introduced in this branch',
+    () {
+      expect(getDevChangesCount([]), isZero);
+      expect(
+        getDevChangesCount([
+          '# Changelog',
+          '',
+          '## 0.0.4-dev.3 - 2021-03-08',
+          '',
+          '* Fixed loading and error builders on empty stream data',
+          '* Update README.md',
+          '',
+          '## 0.0.3 - 2021-03-01',
+        ]),
+        isZero,
+      );
+      expect(
+        getDevChangesCount([
+          '# Changelog',
+          '',
+          '## MINOR',
+          '',
+          '## 0.0.4-dev.3 - 2021-03-08',
+          '',
+          '* Fixed loading and error builders on empty stream data',
+          '* Update README.md',
+        ]),
+        isZero,
+      );
+      expect(
+        getDevChangesCount([
+          '# Changelog',
+          '',
+          '## MINOR',
+          '',
+          '* changes',
+          '',
+          '## 0.0.4-dev.3 - 2021-03-08',
+          '',
+          '* Fixed loading and error builders on empty stream data',
+          '* Update README.md',
+        ]),
+        equals(1),
+      );
+    },
+  );
+
+  test(
+    'getLineImportance returns importance of passed line',
+    () {
+      expect(getLineImportance(''), equals(ChangesImportance.unknown));
+      expect(
+        getLineImportance(
+            '* Fixed loading and error builders on empty stream data'),
+        equals(ChangesImportance.unknown),
+      );
+      expect(
+        getLineImportance(
+            '* Fixed loading and error builders on empty stream data (patch)'),
+        equals(ChangesImportance.patch),
+      );
+      expect(
+        getLineImportance(
+            '* Fixed loading and error builders on empty stream data (minor)'),
+        equals(ChangesImportance.minor),
+      );
+    },
+  );
+
+  test(
+    'getReleaseLineIndices returns lines indices with release paragraphs',
+    () {
+      expect(getReleaseLineIndices([]), isEmpty);
+      expect(
+        getReleaseLineIndices([
+          '# Changelog',
+          '',
+          '## MINOR',
+          '',
+          '* changes',
+          '',
+          '## 0.0.4-dev.3 - 2021-03-08',
+          '',
+          '* Fixed loading and error builders on empty stream data',
+          '* Update README.md',
+        ]),
+        equals([2, 6]),
+      );
+    },
+  );
+
+  test('patchChangelog returns patched content', () {
+    expect(
+      patchChangelog(
+        [
+          '# Changelog',
+          '',
+          '## MINOR',
+          '',
+          '* changes',
+          '',
+          '## 0.0.4-dev.3 - 2021-03-08',
+          '',
+          '* Fixed loading and error builders on empty stream data',
+          '* Update README.md',
+        ],
+        'newVersion',
+        ChangesImportance.major,
+        DateTime(2021, 1, 2),
+      ),
+      equals([
+        '# Changelog',
+        '',
+        '## newVersion - 2021-01-02',
+        '',
+        '* changes (major)',
+        '',
+        '## 0.0.4-dev.3 - 2021-03-08',
+        '',
+        '* Fixed loading and error builders on empty stream data',
+        '* Update README.md',
+      ]),
+    );
+  });
+}

--- a/tools/ci-cd/test/changelog_test.dart
+++ b/tools/ci-cd/test/changelog_test.dart
@@ -15,6 +15,7 @@
 @TestOn('vm')
 import 'package:ci_cd/src/changelog.dart';
 import 'package:ci_cd/src/importance.dart';
+import 'package:pub_semver/pub_semver.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -221,14 +222,14 @@ void main() {
           '* Fixed loading and error builders on empty stream data',
           '* Update README.md',
         ],
-        'newVersion',
+        Version(1, 0, 0),
         ChangesImportance.major,
         DateTime(2021, 1, 2),
       ),
       equals([
         '# Changelog',
         '',
-        '## newVersion - 2021-01-02',
+        '## 1.0.0 - 2021-01-02',
         '',
         '* changes (major)',
         '',

--- a/tools/ci-cd/test/pubspec_test.dart
+++ b/tools/ci-cd/test/pubspec_test.dart
@@ -1,0 +1,61 @@
+@TestOn('vm')
+import 'package:ci_cd/src/pubspec.dart';
+import 'package:pub_semver/pub_semver.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('getPackageVersion returns', () {
+    test('0.0.0 for empty pubspec', () {
+      expect(getPackageVersion([]), equals(Version(0, 0, 0)));
+      expect(
+        getPackageVersion([
+          'name: relation',
+          'description: the stream representation of the relations of the entities and widget utilities',
+        ]),
+        equals(Version(0, 0, 0)),
+      );
+    });
+    test('version from provided pubspec content', () {
+      expect(
+        getPackageVersion([
+          'name: relation',
+          'version: 0.10.0-dev.5',
+          'description: the stream representation of the relations of the entities and widget utilities',
+        ]),
+        equals(Version(0, 10, 0, pre: 'dev.5')),
+      );
+    });
+  });
+
+  test('patchPubspec returns patched content', () {
+    expect(patchPubspec([], Version(1, 0, 0)), equals(<String>[]));
+    expect(
+      patchPubspec(
+        [
+          'name: relation',
+          'description: the stream representation of the relations of the entities and widget utilities',
+        ],
+        Version(1, 0, 0),
+      ),
+      equals([
+        'name: relation',
+        'description: the stream representation of the relations of the entities and widget utilities',
+      ]),
+    );
+    expect(
+      patchPubspec(
+        [
+          'name: relation',
+          'version: 0.10.0',
+          'description: the stream representation of the relations of the entities and widget utilities',
+        ],
+        Version(1, 0, 0),
+      ),
+      equals([
+        'name: relation',
+        'version: 1.0.0',
+        'description: the stream representation of the relations of the entities and widget utilities',
+      ]),
+    );
+  });
+}

--- a/tools/ci-cd/test/version_test.dart
+++ b/tools/ci-cd/test/version_test.dart
@@ -1,0 +1,25 @@
+@TestOn('vm')
+import 'package:ci_cd/src/version.dart';
+import 'package:pub_semver/pub_semver.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('bumpPackageVersion returns increased dev version', () {
+    expect(
+      bumpPackageVersion(Version(0, 10, 0)),
+      equals(Version(0, 10, 0, pre: 'dev.1')),
+    );
+    expect(
+      bumpPackageVersion(Version(1, 0, 0)),
+      equals(Version(1, 0, 0, pre: 'dev.1')),
+    );
+    expect(
+      bumpPackageVersion(Version(1, 2, 3, pre: 'dev.45')),
+      equals(Version(1, 2, 3, pre: 'dev.46')),
+    );
+    expect(
+      bumpPackageVersion(Version(1, 2, 3, pre: 'dev')),
+      equals(Version(1, 2, 3, pre: 'dev.1')),
+    );
+  });
+}


### PR DESCRIPTION
Скрипты для реализации новой концепции поставки изменений в `SurfGear`.

Все pull request’ы сливаются в `main` ветку, при слиянии автоматически публикуется новая - нестабильные версия пакета с суффиксом ( dev-xx ).

Для определения какой будет стабильная версия пакета разработчик должен описать важность вносимых иззменений в файле `CHANGELOG.md`. 

```md
# Changelog

## MAJOR (MINOR или PATCH) - назовем это semver меткой

* short summary of proposed changes
```

при слиянии скрипт правит эту запись в вид:

```md
# Changelog

## latest-stable-version-dev.xx

* short summary of proposed changes (MAJOR … )
```

прописывает соответствующую версию в `pubspec.yaml`, навешивает release tag и публикует свежую версию в `pub`.
