### PR TITLE
fix: tap outside when on drag down navigator pop

### DIFF
--- a/packages/bottom_sheet/lib/src/flexible_bottom_sheet.dart
+++ b/packages/bottom_sheet/lib/src/flexible_bottom_sheet.dart
@@ -418,6 +418,6 @@ class _FlexibleBottomSheetState extends State<FlexibleBottomSheet>
 
   void _dismiss() {
     if (widget.onDismiss != null) widget.onDismiss!();
-    Navigator.pop(context);
+    Navigator.maybePop(context);
   }
 }


### PR DESCRIPTION
If you don't tap up the finger of the bottom sheet while dragging and tap outside, the navigator will pop twice